### PR TITLE
#11 Moving Config, Dashboard and Script to API

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -8,17 +8,26 @@ import * as fs from 'fs'; // In NodeJS: 'const fs = require('fs')'
 export const registerConfigCommands = (context : vscode.ExtensionContext) => {
     vscode.commands.registerCommand('powershell-universal.openConfigFile', openConfigCommand);
     vscode.commands.registerCommand('powershell-universal.reloadConfig', refreshConfig);
+    vscode.workspace.onDidSaveTextDocument((file) => {
+        if(file.fileName.includes('.universal.code.configuration')){
+            const fileName = path.basename(file.fileName);
+            Container.universal.saveConfiguration(fileName, file.getText());
+        }
+    });
 }
 
 export const openConfigCommand = async (item : ConfigTreeItem) => {
     const settings = await Container.universal.getSettings();
-    const filePath = path.join(settings.repositoryPath, '.universal', item.fileName);
-
-    if (!fs.existsSync(filePath)) {
-        fs.writeFileSync(filePath, '');
+    const filePath = path.join(settings.repositoryPath, '.universal.code.configuration', item.fileName);
+    const codePath = path.join(settings.repositoryPath, '.universal.code.configuration');
+    const config = await Container.universal.getConfiguration(item.fileName);
+    if (!fs.existsSync(codePath)){
+        fs.mkdirSync(codePath);
     }
+    fs.writeFileSync(filePath, config);
+    
 
-    const textDocument = await vscode.workspace.openTextDocument(filePath);
+    const textDocument = await vscode.workspace.openTextDocument(filePath);    
 
     vscode.window.showTextDocument(textDocument);
 }

--- a/src/configuration-treeview.ts
+++ b/src/configuration-treeview.ts
@@ -15,21 +15,10 @@ export class ConfigTreeViewProvider implements vscode.TreeDataProvider<vscode.Tr
     async getChildren(element?: vscode.TreeItem | undefined) {
         if (element == null)
         {
-            return [
-                new ConfigTreeItem('Authentication', 'authentication.ps1'),
-                new ConfigTreeItem('Dashboards', 'dashboards.ps1'),
-                new ConfigTreeItem('Dashboard Components', 'dashboard.components.ps1'),
-                new ConfigTreeItem('Dashboard Frameworks', 'dashboard.frameworks.ps1'),
-                new ConfigTreeItem('Endpoints', 'endpoints.ps1'),
-                new ConfigTreeItem('Environments', 'environments.ps1'), 
-                new ConfigTreeItem('Licenses', 'licenses.ps1'),   
-                new ConfigTreeItem('Published Folders', 'publishedFolders.ps1'), 
-                new ConfigTreeItem('Schedules', 'schedules.ps1'), 
-                new ConfigTreeItem('Scripts', 'scripts.ps1'), 
-                new ConfigTreeItem('Settings', 'settings.ps1'), 
-                new ConfigTreeItem('Roles', 'roles.ps1'), 
-                new ConfigTreeItem('Variables', 'variables.ps1'), 
-            ]
+            const configs = await Container.universal.getConfigurations();
+            var configTree: ConfigTreeItem[] = [];
+            configs.forEach(c => configTree.push(new ConfigTreeItem(c,c)));
+            return configTree;
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type Dashboard = {
     status: DashboardStatus;
     processId : number;
     filePath : string;
+    content : string;
     dashboardComponents : Array<DashboardComponent>
 }
 
@@ -89,6 +90,7 @@ export type Script = {
     id : number;
     name : string;
     fullPath : string;
+    content : string;
 }
 
 export type ScriptParameter = {

--- a/src/universal.ts
+++ b/src/universal.ts
@@ -273,7 +273,7 @@ export class Universal {
     getConfiguration(fileName : string) : Promise<string> {
         return new Promise((resolve, reject) => {
             this.request(`/api/v1/configuration/${fileName}`, 'GET')?.then(x => resolve(x.data)).catch(x => {
-                reject('Failed to query configuration.');
+                resolve('');
             })
         })
     }

--- a/src/universal.ts
+++ b/src/universal.ts
@@ -30,7 +30,8 @@ export class Universal {
             url: `${address}:${settings.port}${path}`,
             method,
             headers : {
-                authorization: `Bearer ${settings.appToken}`
+                authorization: `Bearer ${settings.appToken}`,
+                'Content-Type': 'application/json'
             },
             data: data
         });
@@ -164,6 +165,14 @@ export class Universal {
         })
     }
 
+    saveDashboard(id : number, dashboard : Dashboard) {
+        return new Promise((resolve, reject) => {
+            this.request(`/api/v1/dashboard/${id}`, 'PUT', dashboard)?.then(x => resolve(x.data)).catch(x => {
+                reject('Failed to save dashboard.');
+            })
+        })
+    }
+
     getDiagnostics(id : number) : Promise<DashboardDiagnostics> {
         return new Promise((resolve, reject) => {
             this.request(`/api/v1/dashboard/${id}/diagnostics`, 'GET')?.then(x => resolve(x.data)).catch(x => {
@@ -192,6 +201,30 @@ export class Universal {
         return new Promise((resolve, reject) => {
             this.request('/api/v1/script', 'GET')?.then(x => resolve(x.data)).catch(x => {
                 reject('Failed to query scripts.');
+            })
+        })
+    }
+
+    getScript(id : number) : Promise<Script> {
+        return new Promise((resolve, reject) => {
+            this.request(`/api/v1/script/${id}`, 'GET')?.then(x => resolve(x.data)).catch(x => {
+                reject('Failed to query script.');
+            })
+        })
+    }
+
+    getScriptFilePath(filePath : string) : Promise<Script> {
+        return new Promise((resolve, reject) => {
+            this.request(`/api/v1/script/path/${filePath}`, 'GET')?.then(x => resolve(x.data)).catch(x => {
+                reject('Failed to query script.');
+            })
+        })
+    }
+
+    saveScript(script : Script) {
+        return new Promise((resolve, reject) => {
+            this.request(`/api/v1/script/`, 'PUT', script)?.then(x => resolve(x.data)).catch(x => {
+                reject('Failed to save script.');
             })
         })
     }
@@ -225,6 +258,30 @@ export class Universal {
         return new Promise((resolve, reject) => {
             this.request(`/api/v1/settings`, 'GET')?.then(x => resolve(x.data[0])).catch(x => {
                 reject('Failed to query settings.');
+            })
+        })
+    }
+
+    getConfigurations() : Promise<Array<string>> {
+        return new Promise((resolve, reject) => {
+            this.request(`/api/v1/configuration`, 'GET')?.then(x => resolve(x.data)).catch(x => {
+                reject('Failed to query configurations.');
+            })
+        })
+    }
+
+    getConfiguration(fileName : string) : Promise<string> {
+        return new Promise((resolve, reject) => {
+            this.request(`/api/v1/configuration/${fileName}`, 'GET')?.then(x => resolve(x.data)).catch(x => {
+                reject('Failed to query configuration.');
+            })
+        })
+    }
+
+    saveConfiguration(fileName : string, data : string) {
+        return new Promise((resolve, reject) => {
+            this.request(`/api/v1/configuration/${fileName}`, 'PUT', data)?.then(x => resolve(x.data)).catch(x => {
+                reject('Failed to save configuration.');
             })
         })
     }


### PR DESCRIPTION
Added code to move all these over to using the API. On get of (script, config, dash) we save a temp working file to disk. On save event we then push the contents back to the API