### PR TITLE
Update runTest.ts

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -13,7 +13,9 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		if( vscode.workspace.workspaceFolders) {
+			await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		}		
 	} catch (err) {
 		console.error('Failed to run tests');
 		process.exit(1);


### PR DESCRIPTION
The purpose of this change is to avoid an error when the workspace folder does not exist yet. This can happen with a clean installation of VS Code. I referenced https://github.com/microsoft/vscode-cpptools/pull/5054/files.