### PR TITLE
Updated the Changelog markdown to match page on docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Change Log
 
-[Changelog](https://docs.ironmansoftware.com/extension-changelog)
+[Changelog](https://docs.powershelluniversal.com/changelogs/extension-changelog)


### PR DESCRIPTION
Noticed when looking at https://forums.ironmansoftware.com/t/vscode-extension-outdated/12135/2 that the changelog display in the Extension in VSCode results in a page not found.

![image](https://github.com/user-attachments/assets/180634eb-854c-46fc-b008-3fa65aef3d04)

Very very very trivial